### PR TITLE
Make device Name properties return values in a consistent format

### DIFF
--- a/Camera.Simulator/Camera.cs
+++ b/Camera.Simulator/Camera.cs
@@ -63,6 +63,9 @@ namespace ASCOM.Simulators
         // Driver ID and descriptive string that shows in the Chooser
         private static string s_csDriverDescription = "Camera V3 simulator";
 
+        // Value returned through the Name property
+        private const string DEVICE_NAME="Alpaca Camera Simulator";
+
         #region Profile string constants
 
         private const string UNIQUE_ID_PROFILE_NAME = "UniqueID";
@@ -2222,8 +2225,8 @@ namespace ASCOM.Simulators
             {
                 CheckSupportedInThisInterfaceVersion("Name", 2);
                 CheckConnected("Name");
-                Log.LogMessage("Name", "Sim {0}", SensorName);
-                return "Sim " + SensorName;
+                Log.LogMessage("Name", DEVICE_NAME);
+                return DEVICE_NAME;
             }
         }
 

--- a/CoverCalibratorSimulator/CoverCalibratorSimulator.cs
+++ b/CoverCalibratorSimulator/CoverCalibratorSimulator.cs
@@ -273,7 +273,7 @@ namespace ASCOM.Simulators
         {
             get
             {
-                string name = "CoverCalibrator Simulator";
+                string name = "Alpaca Cover Calibrator Simulator";
                 LogVerbose("Name Get", name);
                 return name;
             }

--- a/DomeSimulator/Hardware.cs
+++ b/DomeSimulator/Hardware.cs
@@ -77,7 +77,7 @@ namespace ASCOM.Simulators
         // Constants
         public static string ALERT_TITLE = "ASCOM Dome Simulator .NET";
 
-        public static string INSTRUMENT_NAME = "Alpaca Dome Sim";
+        public static string INSTRUMENT_NAME = "Alpaca Dome Simulator";
         public static string INSTRUMENT_DESCRIPTION = "ASCOM Dome Simulator .NET";
 
         public static double INVALID_COORDINATE = -100000.0;

--- a/FilterWheelSimulator/FilterWheel.cs
+++ b/FilterWheelSimulator/FilterWheel.cs
@@ -148,7 +148,7 @@ namespace ASCOM.Simulators
         {
             get
             {
-                return "Alpaca Filter Wheel Sim";
+                return "Alpaca Filter Wheel Simulator";
             }
         }
 

--- a/FocuserSimulator/Focuser.cs
+++ b/FocuserSimulator/Focuser.cs
@@ -32,7 +32,7 @@ namespace ASCOM.Simulators
         /// <summary>
         /// Name of the Driver
         /// </summary>
-        private const string name = "Alpaca Focuser Sim";
+        private const string name = "Alpaca Focuser Simulator";
 
         /// <summary>
         /// Description of the driver

--- a/ObservingConditionsSimulator/OCSimulator.cs
+++ b/ObservingConditionsSimulator/OCSimulator.cs
@@ -56,7 +56,7 @@ namespace ASCOM.Simulators
         public const string PROPERTY_WINDSPEED = "WindSpeed";
 
         public const string DRIVER_PROGID = "ASCOM.Simulator.ObservingConditions";
-        public const string DRIVER_DISPLAY_NAME = "Alpaca Observing Conditions Sim"; // Driver description that displays in the ASCOM Chooser.
+        public const string DRIVER_DISPLAY_NAME = "Alpaca Observing Conditions Simulator"; // Driver description that displays in the ASCOM Chooser.
         public const string DEVICE_TYPE = "ObservingConditions";
         public const string OBSERVINGCONDITIONS_DEVICE_NAME = "ObservingConditions";
         public const string SIMULATOR_PROGID = "Simulator";

--- a/RotatorSimulator/RotatorHardware.cs
+++ b/RotatorSimulator/RotatorHardware.cs
@@ -38,7 +38,7 @@ namespace ASCOM.Simulators
         private static bool s_bDirection;
         private static float s_fTargetPosition;
         private static int s_iUpdateInterval = 250;			// Milliseconds, default, set by main form
-        private static string _rotatorName = "Alpaca Rotator Sim";
+        private static string _rotatorName = "Alpaca Rotator Simulator";
         private static string _description = "ASCOM Rotator Driver for RotatorSimulator";
         private static string _driverInfo = "ASCOM.Simulator.Rotator";
         private static short _interfaceVersion = 3;

--- a/SafetyMonitorSimulator/SafetyMonitor.cs
+++ b/SafetyMonitorSimulator/SafetyMonitor.cs
@@ -27,7 +27,7 @@ namespace ASCOM.Simulators
         /// <summary>
         /// Name of the Driver
         /// </summary>
-        private const string name = "Alpaca SafetyMonitor Sim";
+        private const string name = "Alpaca Safety Monitor Simulator";
 
         /// <summary>
         /// Description of the driver

--- a/SwitchSimulator/Switch.cs
+++ b/SwitchSimulator/Switch.cs
@@ -253,7 +253,7 @@ namespace ASCOM.Simulators
         {
             get
             {
-                string name = "Alpaca Switch V2 Sim";
+                string name = "Alpaca Switch Simulator";
                 LogMessage("Name Get", name);
                 return name;
             }

--- a/TelescopeSimulator/SharedResources.cs
+++ b/TelescopeSimulator/SharedResources.cs
@@ -82,7 +82,7 @@ namespace ASCOM.Simulators
 
         internal const double INSTRUMENT_APERTURE_AREA = 0.0269;    // 3 inch obstruction
         internal const double INSTRUMENT_FOCAL_LENGTH = 1.26;      // f/6.3 instrument
-        public const string INSTRUMENT_NAME = "Alpaca Telescope Sim";       // Our name
+        public const string INSTRUMENT_NAME = "Alpaca Telescope Simulator";       // Our name
         public const string INSTRUMENT_DESCRIPTION = "Software Telescope Simulator for ASCOM";
 
         internal const uint ERROR_BASE = 0x80040400;


### PR DESCRIPTION
To solve my problem of being able to identify OmniSim devices in ConformU I propose making the OmniSim Name property return a consistent response for all devices.  This will enable OmniSim devices to be detected without the need for new methods or a special Action commands. It seemed to be the least destructive of the options I could see.

Some devices already used the Name format "Alpaca DeviceName Sim" so I've worked with that and propose that we go with "Alpaca DeviceName Simulator" where DeviceName can be a single word such as Camera or two words such as Focus Simulator.

Hopefully you agree with this approach.

Best wishes, Peter