### PR TITLE
Fixed Switch UI: only odd-numbered switches were displayed.

### DIFF
--- a/ASCOM.Alpaca.Simulators/Pages/SwitchControl.razor
+++ b/ASCOM.Alpaca.Simulators/Pages/SwitchControl.razor
@@ -38,8 +38,6 @@
                         <th><input type="range" min="@Device.MinSwitchValue(i)" max="@Device.MaxSwitchValue(i)" step="@Device.SwitchStep(i)" value="@Device.GetSwitchValue(i)" @onchange="@((ChangeEventArgs __e) => SetValue(index, Convert.ToDouble(__e.Value)))" style="min-width:40ch"></th>
                         <th>@Device.GetSwitchValue(i)</th>
                     </tr>
-
-                    i++;
                 }
             }
         </table>


### PR DESCRIPTION
In the simulator UI, at Switch page, when connected only the odd-numbered switches where visible because there was an increment of the loop variable inside the loop itself.
