### PR TITLE
Fix Dome UI for roll-off roof use case (review)

### DIFF
--- a/ASCOM.Alpaca.Simulators/Pages/DomeControl.razor
+++ b/ASCOM.Alpaca.Simulators/Pages/DomeControl.razor
@@ -169,14 +169,17 @@
         {
             if (Connected)
             {
-                if (Device.CanSetShutter && Device.Altitude != -100000.0)
+                if (Device.CanSetShutter)
                 {
                     switch (Device.ShutterStatus)
                     {
                         case ShutterState.Open:
                             if (Device.CanSetAltitude)
                             {
-                                return Device.Altitude.ToString("0.0");
+                                if (Device.Altitude != -100000.0)
+                                    return Device.Altitude.ToString("0.0");
+                                else
+                                    return "----";
                             }
                             else
                             {
@@ -204,7 +207,7 @@
         {
             if (Connected)
             {
-                if (Device.Azimuth != -100000.0)
+                if (Device.CanSetAzimuth && Device.Azimuth != -100000.0)
                 {
                     return Device.Azimuth.ToString("000.0");
                 }


### PR DESCRIPTION
In roll off roof the only interface capability enabled is "Can Open Close Shutter".
With this configuration reading Device.Altitude and Device.Azimuth throw errors.
I modified the DomeControl page to check first if this properties can be read, and avoid exceptions