### PR TITLE
Real Sky Image from online service

### DIFF
--- a/ASCOM.Alpaca.Simulators/Pages/CameraSetup.razor
+++ b/ASCOM.Alpaca.Simulators/Pages/CameraSetup.razor
@@ -196,7 +196,14 @@
 
     <fieldset disabled="@Device.Connected">
         <legend>Simulated Image</legend>
-        <p>Coming Soon!</p>
+
+        <label for="ImageSource">Image Source</label>
+        <select id="ImageSource" @bind="ImageSource">
+            <option value="File">File</option>
+            <option value="Hipps2Fits">Online Service</option>
+        </select>
+        <br>
+        <p>Online Service make use of <a href="https://alasky.u-strasbg.fr/hips-image-services/hips2fits" target="_blank">hips2fits</a> a service provided by CDS.</p>
     </fieldset>
 
     <fieldset disabled="@Device.Connected">
@@ -305,6 +312,8 @@
         CanPulseGuide = Device.canPulseGuide;
 
         CanImageBytes = ServerSettings.AllowImageBytesDownload;
+
+        ImageSource = Device.imageSource;
 
         base.OnInitialized();
     }
@@ -521,6 +530,12 @@
         set;
     }
 
+    ASCOM.Simulators.Camera.ImageSource ImageSource
+    {
+        get;
+        set;
+    }
+
     #endregion
 
     public void Reset()
@@ -717,6 +732,8 @@
             Device.offsetMax = OffsetMax;
 
             Device.canPulseGuide = CanPulseGuide;
+
+            Device.imageSource = ImageSource;
 
             Device.SaveToProfile();
 

--- a/Camera.Simulator/CameraSimulator.csproj
+++ b/Camera.Simulator/CameraSimulator.csproj
@@ -5,12 +5,14 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="ASCOM.AstrometryTools" Version="2.0.5" />
     <PackageReference Include="ASCOM.Common.Components" Version="2.0.5" />
     <PackageReference Include="ASCOM.Exception.Library" Version="7.0.1" />
     <PackageReference Include="SixLabors.ImageSharp" Version="2.1.3" />
   </ItemGroup>
 
   <ItemGroup>
+    <ProjectReference Include="..\ASCOM.Alpaca.Razor\ASCOM.Alpaca.Razor.csproj" />
     <ProjectReference Include="..\OmniSim.Tools\OmniSim.Tools.csproj" />
   </ItemGroup>
 

--- a/Camera.Simulator/IImageService.cs
+++ b/Camera.Simulator/IImageService.cs
@@ -1,0 +1,26 @@
+﻿using SixLabors.ImageSharp;
+using SixLabors.ImageSharp.PixelFormats;
+using System.Threading.Tasks;
+
+namespace CameraSimulator
+{
+    internal interface IImageService
+    {
+        double RightAscension { get; set; }
+        double Declination { get; set; }
+        double Fov { get; set; }
+        int Height { get; set; }
+        int Width { get; set; }
+        double RotationAngle { get; set; }
+
+        bool ImageReady { get; }
+
+        /// <summary>
+        /// Task to wait for asyncronous download
+        /// </summary>
+        Task DataReadyTask { get; }
+
+        Image<Rgba32> GetImage();
+        void StartRequest();
+    }
+}

--- a/Camera.Simulator/ImageServiceFile.cs
+++ b/Camera.Simulator/ImageServiceFile.cs
@@ -1,0 +1,41 @@
+﻿using SixLabors.ImageSharp;
+using SixLabors.ImageSharp.Formats.Jpeg;
+using SixLabors.ImageSharp.Formats;
+using SixLabors.ImageSharp.PixelFormats;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace CameraSimulator
+{
+    internal class ImageServiceFile : IImageService
+    {
+        public double RightAscension { get; set; }
+        public double Declination { get; set; }
+        public double Fov { get; set; }
+        public int Height { get; set; }
+        public int Width { get; set; }
+        public double RotationAngle { get; set; }
+
+        public bool ImageReady { get; set; }
+
+        public Task DataReadyTask => Task.CompletedTask;
+
+        private IImageDecoder decoder = new JpegDecoder();
+        Image<Rgba32> image;
+
+        public ImageServiceFile(string filepath)
+        {
+           image= Image.Load<Rgba32>(filepath);
+        }
+
+        public Image<Rgba32> GetImage()
+        {
+            return image;
+        }
+
+        public void StartRequest()
+        {
+            // nothing to do            
+        }
+    }
+}

--- a/Camera.Simulator/ImageServiceH2F.cs
+++ b/Camera.Simulator/ImageServiceH2F.cs
@@ -1,0 +1,105 @@
+﻿using ASCOM.Common;
+using ASCOM.Simulators;
+using Microsoft.AspNetCore.Builder;
+using SixLabors.ImageSharp;
+using SixLabors.ImageSharp.Formats;
+using SixLabors.ImageSharp.Formats.Jpeg;
+using SixLabors.ImageSharp.Formats.Png;
+using SixLabors.ImageSharp.PixelFormats;
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Globalization;
+using System.Linq;
+using System.Net.Http;
+using System.Text;
+using System.Threading.Tasks;
+using System.Web;
+
+namespace CameraSimulator
+{
+    internal class ImageServiceH2F : IImageService
+    {
+        // Public query Parameters
+        public int Width { get; set; } = 800;
+        public int Height { get; set; } = 600;
+        public double Fov { get; set; } = 0.77;
+        public double RotationAngle { get; set; } = 0.0;
+        public double RightAscension { get; set; } = 83.6287;
+        public double Declination { get; set; } = 22.0147;
+
+        // Private parameters
+        string baseUrl = "https://alasky.cds.unistra.fr/hips-image-services/hips2fits";
+        string alternateUrl = "http://alaskybis.cds.unistra.fr/hips-image-services/hips2fits";
+        private string Hips = "CDS/P/DSS2/color";
+        private string Projection = "TAN";
+        private string CoordSys = "icrs";
+
+        // HttpClient is intended to be instantiated once per application, rather than per-use.
+        private static readonly HttpClient httpClient = new HttpClient();
+        private byte[] lastImage;
+        private TaskCompletionSource<bool> _taskCompletionSource = new TaskCompletionSource<bool>();
+        private IImageDecoder decoder = new JpegDecoder();
+
+        public bool ImageReady { get; private set; }
+        public Task DataReadyTask => _taskCompletionSource.Task;
+
+        public Image<Rgba32> GetImage()
+        {
+            if (!ImageReady)
+                return null;
+            var image = Image.Load<Rgba32>(lastImage, decoder);
+            ImageReady = false;
+            lastImage = null;
+            return image;
+        }
+
+        public void StartRequest()
+        {
+            ImageReady = false;
+            if (_taskCompletionSource.Task.IsCompleted)
+            {
+                _taskCompletionSource = new TaskCompletionSource<bool>();
+            }
+
+            // Call asynchronous network methods in a try/catch block to handle exceptions.
+            try
+            {
+                var tr = new ASCOM.Tools.Transform();
+                tr.SetApparent(RightAscension, Declination);
+
+                var builder = new UriBuilder(baseUrl);
+                var query = HttpUtility.ParseQueryString(string.Empty);
+                query["hips"] = Hips;
+                query["width"] = Width.ToString(CultureInfo.InvariantCulture);
+                query["height"] = Height.ToString(CultureInfo.InvariantCulture);
+                query["fov"] = Fov.ToString(CultureInfo.InvariantCulture);
+                query["projection"] = Projection;
+                query["coordsys"] = CoordSys;
+                query["rotation_angle"] = RotationAngle.ToString(CultureInfo.InvariantCulture);
+                query["ra"] = (tr.RAJ2000 * 15).ToString("0.0000", CultureInfo.InvariantCulture);
+                query["dec"] = tr.DecJ2000.ToString("0.0000", CultureInfo.InvariantCulture);
+                query["format"] = "jpg";
+
+                builder.Query = query.ToString();
+                var requestUrl = builder.ToString();
+
+                Log.LogMessage("ImageServiceH2F", "Hips2fits Web Api request sended");
+                Log.log.LogDebug($"ImageServiceH2F - reques URL:{requestUrl}");
+
+                var requestTask = httpClient.GetByteArrayAsync(requestUrl).ContinueWith(t =>
+                 {
+                     lastImage = t.Result;
+                     ImageReady = true;
+                     _taskCompletionSource.SetResult(true);
+                     Log.LogMessage("ImageServiceH2F", "Hips2fits image donload complete.");
+                 });
+            }
+            catch (Exception ex)
+            {
+                Log.LogMessage("ImageServiceH2F", $"Exception: {ex.GetType().Name} - {ex.Message}");
+            }
+        }
+
+    }
+}


### PR DESCRIPTION
Use the CDS HiPS2FITS web service to load real sky images based on the telescope's position, focal length, rotator position, and camera sensor size.
A new option is available in the "Simulated Image" section of the CameraSetup page, allowing you to choose between the static file or a web service request for the image.

Please ensure the focal length is correctly set in the telescope settings.
Additionally, the camera settings should include the pixel size (width and height in microns) and the CCD dimensions (width and height in pixels) for accurate results.