### PR TITLE
Significantly reduce the number of compilation warnings 

### DIFF
--- a/ASCOM.Alpaca.Razor/ASCOM.Alpaca.Razor.csproj
+++ b/ASCOM.Alpaca.Razor/ASCOM.Alpaca.Razor.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>
-    <Nullable>enable</Nullable>
+    <Nullable>disable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
   </PropertyGroup>
 

--- a/ASCOM.Alpaca.Razor/Authentication/AuthorizationFilter.cs
+++ b/ASCOM.Alpaca.Razor/Authentication/AuthorizationFilter.cs
@@ -56,7 +56,7 @@ namespace ASCOM.Alpaca
             }
 
             // Auth failed, block request
-            filterContext.HttpContext.Response.Headers.Add("WWW-Authenticate", string.Format("Basic realm=\"{0}\"", BasicRealm ?? "Alpaca"));
+            filterContext.HttpContext.Response.Headers.Append("WWW-Authenticate", string.Format("Basic realm=\"{0}\"", BasicRealm ?? "Alpaca"));
             filterContext.Result = new UnauthorizedResult();
         }
     }

--- a/ASCOM.Alpaca.Razor/Controllers/ObservingConditionsController.cs
+++ b/ASCOM.Alpaca.Razor/Controllers/ObservingConditionsController.cs
@@ -434,7 +434,7 @@ namespace ASCOM.Alpaca
         [Route("{DeviceNumber}/timesincelastupdate")]
         public ActionResult<DoubleResponse> TimeSinceLastUpdate(
             [Required][DefaultValue(0)][SwaggerSchema(Strings.DeviceIDDescription, Format = "uint32")][Range(0, 4294967295)] uint DeviceNumber,
-            [SwaggerSchema("Name of the sensor whose description is required")] string? SensorName = "", 
+            [SwaggerSchema("Name of the sensor whose description is required")] string SensorName = "", 
             [SwaggerSchema(Strings.ClientIDDescription, Format = "uint32")][Range(0, 4294967295)] uint ClientID = 0,
             [SwaggerSchema(Strings.ClientTransactionIDDescription, Format = "uint32")][Range(0, 4294967295)] uint ClientTransactionID = 0)
         {

--- a/ASCOM.Alpaca.Razor/Discovery/DiscoveryManager.cs
+++ b/ASCOM.Alpaca.Razor/Discovery/DiscoveryManager.cs
@@ -1,3 +1,5 @@
+// Ignore Spelling: ipv
+
 using ASCOM.Alpaca.Discovery;
 using ASCOM.Common.Interfaces;
 using System;
@@ -6,9 +8,11 @@ using System.Linq;
 using System.Net;
 using System.Net.NetworkInformation;
 using System.Net.Sockets;
+using System.Runtime.Versioning;
 
 namespace ASCOM.Alpaca
 {
+    [UnsupportedOSPlatform("browser")]
     public static class DiscoveryManager
     {
         public static Responder DiscoveryResponder

--- a/ASCOM.Alpaca.Razor/StartupHelpers.cs
+++ b/ASCOM.Alpaca.Razor/StartupHelpers.cs
@@ -1,4 +1,6 @@
-﻿using Microsoft.AspNetCore.Authentication.Cookies;
+﻿// Ignore Spelling: Behavoir
+
+using Microsoft.AspNetCore.Authentication.Cookies;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting.Server.Features;
 using Microsoft.AspNetCore.Mvc;
@@ -9,12 +11,14 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Net;
 using System.Reflection;
+using System.Runtime.Versioning;
 using System.Text;
 using System.Text.Json.Serialization;
 using System.Threading.Tasks;
 
 namespace ASCOM.Alpaca.Razor
 {
+    [UnsupportedOSPlatform("browser")]
     public static class StartupHelpers
     {
         public static void ConfigureSwagger(IServiceCollection services, string host_xml_file)

--- a/ASCOM.Alpaca.Simulators/Program.cs
+++ b/ASCOM.Alpaca.Simulators/Program.cs
@@ -58,6 +58,7 @@ namespace ASCOM.Alpaca.Simulators
             }
 
 #if ASCOM_COM
+            Debug.Assert(OperatingSystem.IsWindows());
             OmniSim.LocalServer.Server.InitServer();
             OmniSim.LocalServer.Drivers.Camera.DeviceAccess = () => ASCOM.Alpaca.DeviceManager.GetCamera(0);
             OmniSim.LocalServer.Drivers.CoverCalibrator.DeviceAccess = () => ASCOM.Alpaca.DeviceManager.GetCoverCalibrator(0);
@@ -74,6 +75,7 @@ namespace ASCOM.Alpaca.Simulators
             {
                 return;
             }
+            Debug.Assert(!OperatingSystem.IsWindows());
 #endif
 
             try

--- a/ASCOM.Alpaca.Simulators/Shared/NavMenu.razor
+++ b/ASCOM.Alpaca.Simulators/Shared/NavMenu.razor
@@ -104,7 +104,7 @@
         {
             Startup.Lifetime.StopApplication();
         }
-        catch (Exception ex)
+        catch (Exception)
         {
             
         }

--- a/ASCOM.Alpaca.Simulators/Shared/NavMenu.razor
+++ b/ASCOM.Alpaca.Simulators/Shared/NavMenu.razor
@@ -1,3 +1,4 @@
+@using Microsoft.AspNetCore.Components.Routing
 <div class="top-row pl-4 navbar navbar-dark">
     <a class="navbar-brand" href="">ASCOM.Alpaca.Simulators</a>
     <button class="navbar-toggler" @onclick="ToggleNavMenu">

--- a/ASCOM.COM.LocalServer/ClassFactory.cs
+++ b/ASCOM.COM.LocalServer/ClassFactory.cs
@@ -1,6 +1,9 @@
+// Ignore Spelling: IID prog
+
 using System;
 using System.Collections;
 using System.Runtime.InteropServices;
+using System.Runtime.Versioning;
 
 namespace OmniSim.LocalServer
 {
@@ -24,6 +27,7 @@ namespace OmniSim.LocalServer
     /// <summary>
     /// Universal ClassFactory. Given a type as a parameter of the constructor, it implements IClassFactory for any interface that the class implements. Magic!!!
     /// </summary>
+    [SupportedOSPlatform("windows")]
     public class ClassFactory : IClassFactory
     {
 

--- a/ASCOM.COM.LocalServer/GarbageCollection.cs
+++ b/ASCOM.COM.LocalServer/GarbageCollection.cs
@@ -17,11 +17,6 @@ namespace OmniSim.LocalServer
 
         public void GCWatch(CancellationToken token)
         {
-            if (token == null)
-            {
-                throw new ArgumentException("GCWatch was called with a null cancellation token!");
-            }
-
             bool taskCancelled = false;
 
             while (!taskCancelled)

--- a/ASCOM.COM.LocalServer/LocalServer.cs
+++ b/ASCOM.COM.LocalServer/LocalServer.cs
@@ -22,10 +22,12 @@ using System.Diagnostics;
 using System.Reflection;
 using System.Reflection.Emit;
 using System.Runtime.InteropServices;
+using System.Runtime.Versioning;
 using System.Security.Principal;
 
 namespace OmniSim.LocalServer
 {
+    [SupportedOSPlatform("windows")]
     public class Server
     {
         #region Variables
@@ -739,7 +741,7 @@ namespace OmniSim.LocalServer
                 TL.LogMessage("IsAdministrator", $"Starting elevated process");
                 Process.Start(processStartInfo);
             }
-            catch (System.ComponentModel.Win32Exception e)
+            catch (System.ComponentModel.Win32Exception)
             {
                 TL.LogMessage("IsAdministrator", $"The OmniSim was not " + (argument == "/register" ? "registered" : "unregistered") + " because you did not allow it.");
                 NativeMethods.MessageBox(System.IntPtr.Zero, $"The OmniSim was not " + (argument == "/register" ? "registered" : "unregistered") + " because you did not allow it.", "OmniSim COM", 0);

--- a/ASCOM.COM.LocalServer/OmniSim.LocalServer.csproj
+++ b/ASCOM.COM.LocalServer/OmniSim.LocalServer.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
-    <Nullable>enable</Nullable>
+    <Nullable>disable</Nullable>
     <OutputType>Library</OutputType>
   </PropertyGroup>
 

--- a/ASCOM.COM.LocalServer/ReferenceCountedObject.cs
+++ b/ASCOM.COM.LocalServer/ReferenceCountedObject.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Runtime.InteropServices;
+using System.Runtime.Versioning;
 
 namespace OmniSim.LocalServer
 {
@@ -7,6 +8,7 @@ namespace OmniSim.LocalServer
     /// Class to keep track of COM object instanciations and destructions
     /// </summary>
     [ComVisible(false)]
+    [SupportedOSPlatform("windows")]
     public class ReferenceCountedObjectBase
     {
         /// <summary>

--- a/FocuserSimulator/Focuser.cs
+++ b/FocuserSimulator/Focuser.cs
@@ -156,7 +156,7 @@ namespace ASCOM.Simulators
             catch (Exception ex)
             {
                 TL.LogError(ex.Message.ToString());
-                throw ex;
+                throw;
             }
         }
 

--- a/ObservingConditionsSimulator/OCSimulator.cs
+++ b/ObservingConditionsSimulator/OCSimulator.cs
@@ -13,6 +13,8 @@
 // Written by:	Bob Denny	29-May-2007
 // Modified by Chris Rowland and Peter Simpson to handle multiple hardware devices March 2011
 //
+// Ignore Spelling: CLOUDCOVER DEWPOINT RAINRATE SKYBRIGHTNESS SKYQUALITY STARFWHM SKYTEMPERATURE WINDDIRECTION WINDGUST WINDSPEED OBSERVINGCONDITIONS SENSORVIEW PROGID SIMTOVALUE PROFILENAME SIMFROMVALUE
+
 using ASCOM.Common;
 using ASCOM.Common.Interfaces;
 using System;
@@ -316,7 +318,7 @@ namespace ASCOM.Simulators
             catch (Exception ex)
             {
                 TL.LogError(ex.Message);
-                throw ex;
+                throw;
             }
         }
 

--- a/RotatorSimulator/Rotator.cs
+++ b/RotatorSimulator/Rotator.cs
@@ -76,7 +76,7 @@ namespace ASCOM.Simulators
             catch (Exception ex)
             {
                 logger.LogError(ex.Message.ToString());
-                throw ex;
+                throw;
             }
         }
 


### PR DESCRIPTION
This makes non-functional changes to reduce the number of compiler warnings, which were over 200 on the build machine. This is mostly achieved by disabling the default nullable context in some projects and by flagging methods that are only available in Windows so that they do not generate warnings when compiled for non-Windows OS. I'm now seeing a handful of warnings on my development PC.

Hopefully we can now "see the wood for the trees".