### PR TITLE
Adding missing COPY commands in Dockerfile

### DIFF
--- a/ASCOM.Alpaca.Razor/StartupHelpers.cs
+++ b/ASCOM.Alpaca.Razor/StartupHelpers.cs
@@ -32,8 +32,9 @@ namespace ASCOM.Alpaca.Razor
                     //This is off for now
                     //c.UseOneOfForPolymorphism();
 
-                    c.SwaggerDoc("Alpaca", new OpenApiInfo { Title = $"{DeviceManager.Configuration.ServerName}", Description = "Please note that the Alpaca API documentation on the ASCOM website is the canonical version. There are several issues with this auto generated version that will be resolved in future versions. This is currently provided only for testing..", Version = "v1" });
-                    c.SwaggerDoc("OmniSim", new OpenApiInfo { Title = "OmniSim Setup", Version = "v1" });
+                    c.SwaggerDoc("Alpaca", new OpenApiInfo { Title = $"{DeviceManager.Configuration.ServerName}", Description = "The Alpaca JSON API Specification. You can find the Alpaca HTML Specification and the OmniSim only configuration specification in the drop down. Please note that the Alpaca API documentation on the ASCOM website is the canonical version. There are several issues with this auto generated version that will be resolved in future versions. This is currently provided only for testing.", Version = "v1" });
+                    c.SwaggerDoc("AlpacaSetup", new OpenApiInfo { Title = $"{DeviceManager.Configuration.ServerName}", Description = "Alpaca HTML Setup API - These are used to give the end user a GUI to configure device specific settings.", Version = "v1" });
+                    c.SwaggerDoc("OmniSim", new OpenApiInfo { Title = "OmniSim JSON API", Description="API configuration that is unique to the OmniSim. These are not part of the Alpaca Spec but are helpful to automate testing with the OmniSim.", Version = "v1" });
 
 
                     if (File.Exists(host_xml_file))
@@ -81,7 +82,9 @@ namespace ASCOM.Alpaca.Razor
                 app.UseSwagger();
                 app.UseSwaggerUI(c => {
                     c.SwaggerEndpoint("/swagger/Alpaca/swagger.json",
-                                 $"Alpaca Endpoints - v1");
+                                 $"Alpaca JSON Endpoints - v1");
+                    c.SwaggerEndpoint("/swagger/AlpacaSetup/swagger.json",
+             $"Alpaca HTML Endpoints - v1");
                     c.SwaggerEndpoint("/swagger/OmniSim/swagger.json", "OmniSim Only Endpoints");
                     c.DocExpansion(DocExpansion.None);
                 });

--- a/ASCOM.Alpaca.Simulators/Controllers/FilterWheelSettingsController.cs
+++ b/ASCOM.Alpaca.Simulators/Controllers/FilterWheelSettingsController.cs
@@ -17,8 +17,8 @@ namespace ASCOM.Alpaca.Simulators
     [ServiceFilter(typeof(AuthorizationFilter))]
     [ApiController]
     [Route("simulator/v1/")]
-public class FilterWheelSettingsController : ProcessBaseController
-{
+    public class FilterWheelSettingsController : ProcessBaseController
+    {
         /// <summary>
         /// OmniSim Only - Time to move between filter positions (milliseconds)
         /// </summary>
@@ -33,7 +33,8 @@ public class FilterWheelSettingsController : ProcessBaseController
         /// <response code="500" examples="Error message describing why the command cannot be processed">Server internal error, check error message</response>
         [HttpGet]
         [Produces(MediaTypeNames.Application.Json)]
-        [ApiExplorerSettings(GroupName = "OmniSim")]        [Route("filterwheel/{DeviceNumber}/filterchangetimeinterval")]
+        [ApiExplorerSettings(GroupName = "OmniSim")]
+        [Route("filterwheel/{DeviceNumber}/filterchangetimeinterval")]
         public ActionResult<ASCOM.Common.Alpaca.IntResponse> FilterChangeTimeInterval(
             [Required][DefaultValue(0)][SwaggerSchema(Strings.DeviceIDDescription, Format = "uint32")][Range(0, 4294967295)] uint DeviceNumber,
             [SwaggerSchema(Strings.ClientIDDescription, Format = "uint32")][Range(0, 4294967295)] uint ClientID = 0,
@@ -56,7 +57,8 @@ public class FilterWheelSettingsController : ProcessBaseController
         /// <response code="500" examples="Error message describing why the command cannot be processed">Server internal error, check error message</response>
         [HttpPut]
         [Produces(MediaTypeNames.Application.Json)]
-        [ApiExplorerSettings(GroupName = "OmniSim")]        [Route("filterwheel/{DeviceNumber}/filterchangetimeinterval")]
+        [ApiExplorerSettings(GroupName = "OmniSim")]
+        [Route("filterwheel/{DeviceNumber}/filterchangetimeinterval")]
         public ActionResult<Response> FilterChangeTimeInterval(
             [Required][DefaultValue(0)][SwaggerSchema(Strings.DeviceIDDescription, Format = "uint32")][Range(0, 4294967295)] uint DeviceNumber,
             [Required][FromForm][SwaggerSchema("Time to move between filter positions (milliseconds)")] System.Int32 FilterChangeTimeInterval,
@@ -79,7 +81,8 @@ public class FilterWheelSettingsController : ProcessBaseController
         /// <response code="500" examples="Error message describing why the command cannot be processed">Server internal error, check error message</response>
         [HttpGet]
         [Produces(MediaTypeNames.Application.Json)]
-        [ApiExplorerSettings(GroupName = "OmniSim")]        [Route("filterwheel/{DeviceNumber}/implementsnames")]
+        [ApiExplorerSettings(GroupName = "OmniSim")]
+        [Route("filterwheel/{DeviceNumber}/implementsnames")]
         public ActionResult<ASCOM.Common.Alpaca.BoolResponse> ImplementsNames(
             [Required][DefaultValue(0)][SwaggerSchema(Strings.DeviceIDDescription, Format = "uint32")][Range(0, 4294967295)] uint DeviceNumber,
             [SwaggerSchema(Strings.ClientIDDescription, Format = "uint32")][Range(0, 4294967295)] uint ClientID = 0,
@@ -102,7 +105,8 @@ public class FilterWheelSettingsController : ProcessBaseController
         /// <response code="500" examples="Error message describing why the command cannot be processed">Server internal error, check error message</response>
         [HttpPut]
         [Produces(MediaTypeNames.Application.Json)]
-        [ApiExplorerSettings(GroupName = "OmniSim")]        [Route("filterwheel/{DeviceNumber}/implementsnames")]
+        [ApiExplorerSettings(GroupName = "OmniSim")]
+        [Route("filterwheel/{DeviceNumber}/implementsnames")]
         public ActionResult<Response> ImplementsNames(
             [Required][DefaultValue(0)][SwaggerSchema(Strings.DeviceIDDescription, Format = "uint32")][Range(0, 4294967295)] uint DeviceNumber,
             [Required][FromForm][SwaggerSchema("True if the driver implements names")] System.Boolean ImplementsNames,
@@ -125,7 +129,8 @@ public class FilterWheelSettingsController : ProcessBaseController
         /// <response code="500" examples="Error message describing why the command cannot be processed">Server internal error, check error message</response>
         [HttpGet]
         [Produces(MediaTypeNames.Application.Json)]
-        [ApiExplorerSettings(GroupName = "OmniSim")]        [Route("filterwheel/{DeviceNumber}/implementsoffsets")]
+        [ApiExplorerSettings(GroupName = "OmniSim")]
+        [Route("filterwheel/{DeviceNumber}/implementsoffsets")]
         public ActionResult<ASCOM.Common.Alpaca.BoolResponse> ImplementsOffsets(
             [Required][DefaultValue(0)][SwaggerSchema(Strings.DeviceIDDescription, Format = "uint32")][Range(0, 4294967295)] uint DeviceNumber,
             [SwaggerSchema(Strings.ClientIDDescription, Format = "uint32")][Range(0, 4294967295)] uint ClientID = 0,
@@ -148,7 +153,8 @@ public class FilterWheelSettingsController : ProcessBaseController
         /// <response code="500" examples="Error message describing why the command cannot be processed">Server internal error, check error message</response>
         [HttpPut]
         [Produces(MediaTypeNames.Application.Json)]
-        [ApiExplorerSettings(GroupName = "OmniSim")]        [Route("filterwheel/{DeviceNumber}/implementsoffsets")]
+        [ApiExplorerSettings(GroupName = "OmniSim")]
+        [Route("filterwheel/{DeviceNumber}/implementsoffsets")]
         public ActionResult<Response> ImplementsOffsets(
             [Required][DefaultValue(0)][SwaggerSchema(Strings.DeviceIDDescription, Format = "uint32")][Range(0, 4294967295)] uint DeviceNumber,
             [Required][FromForm][SwaggerSchema("True if the driver implements offsets")] System.Boolean ImplementsOffsets,
@@ -171,7 +177,8 @@ public class FilterWheelSettingsController : ProcessBaseController
         /// <response code="500" examples="Error message describing why the command cannot be processed">Server internal error, check error message</response>
         [HttpGet]
         [Produces(MediaTypeNames.Application.Json)]
-        [ApiExplorerSettings(GroupName = "OmniSim")]        [Route("filterwheel/{DeviceNumber}/preemptmoves")]
+        [ApiExplorerSettings(GroupName = "OmniSim")]
+        [Route("filterwheel/{DeviceNumber}/preemptmoves")]
         public ActionResult<ASCOM.Common.Alpaca.BoolResponse> PreemptMoves(
             [Required][DefaultValue(0)][SwaggerSchema(Strings.DeviceIDDescription, Format = "uint32")][Range(0, 4294967295)] uint DeviceNumber,
             [SwaggerSchema(Strings.ClientIDDescription, Format = "uint32")][Range(0, 4294967295)] uint ClientID = 0,
@@ -194,7 +201,8 @@ public class FilterWheelSettingsController : ProcessBaseController
         /// <response code="500" examples="Error message describing why the command cannot be processed">Server internal error, check error message</response>
         [HttpPut]
         [Produces(MediaTypeNames.Application.Json)]
-        [ApiExplorerSettings(GroupName = "OmniSim")]        [Route("filterwheel/{DeviceNumber}/preemptmoves")]
+        [ApiExplorerSettings(GroupName = "OmniSim")]
+        [Route("filterwheel/{DeviceNumber}/preemptmoves")]
         public ActionResult<Response> PreemptMoves(
             [Required][DefaultValue(0)][SwaggerSchema(Strings.DeviceIDDescription, Format = "uint32")][Range(0, 4294967295)] uint DeviceNumber,
             [Required][FromForm][SwaggerSchema("True if the driver can interrupt moves")] System.Boolean PreemptMoves,
@@ -217,7 +225,8 @@ public class FilterWheelSettingsController : ProcessBaseController
         /// <response code="500" examples="Error message describing why the command cannot be processed">Server internal error, check error message</response>
         [HttpGet]
         [Produces(MediaTypeNames.Application.Json)]
-        [ApiExplorerSettings(GroupName = "OmniSim")]        [Route("filterwheel/{DeviceNumber}/slots")]
+        [ApiExplorerSettings(GroupName = "OmniSim")]
+        [Route("filterwheel/{DeviceNumber}/slots")]
         public ActionResult<ASCOM.Common.Alpaca.IntResponse> Slots(
             [Required][DefaultValue(0)][SwaggerSchema(Strings.DeviceIDDescription, Format = "uint32")][Range(0, 4294967295)] uint DeviceNumber,
             [SwaggerSchema(Strings.ClientIDDescription, Format = "uint32")][Range(0, 4294967295)] uint ClientID = 0,
@@ -240,7 +249,8 @@ public class FilterWheelSettingsController : ProcessBaseController
         /// <response code="500" examples="Error message describing why the command cannot be processed">Server internal error, check error message</response>
         [HttpPut]
         [Produces(MediaTypeNames.Application.Json)]
-        [ApiExplorerSettings(GroupName = "OmniSim")]        [Route("filterwheel/{DeviceNumber}/slots")]
+        [ApiExplorerSettings(GroupName = "OmniSim")]
+        [Route("filterwheel/{DeviceNumber}/slots")]
         public ActionResult<Response> Slots(
             [Required][DefaultValue(0)][SwaggerSchema(Strings.DeviceIDDescription, Format = "uint32")][Range(0, 4294967295)] uint DeviceNumber,
             [Required][FromForm][SwaggerSchema("Number of filter wheel positions, 1-8")] System.Int32 Slots,
@@ -263,7 +273,8 @@ public class FilterWheelSettingsController : ProcessBaseController
         /// <response code="500" examples="Error message describing why the command cannot be processed">Server internal error, check error message</response>
         [HttpGet]
         [Produces(MediaTypeNames.Application.Json)]
-        [ApiExplorerSettings(GroupName = "OmniSim")]        [Route("filterwheel/{DeviceNumber}/interfaceversion")]
+        [ApiExplorerSettings(GroupName = "OmniSim")]
+        [Route("filterwheel/{DeviceNumber}/interfaceversion")]
         public ActionResult<ASCOM.Common.Alpaca.IntResponse> InterfaceVersion(
             [Required][DefaultValue(0)][SwaggerSchema(Strings.DeviceIDDescription, Format = "uint32")][Range(0, 4294967295)] uint DeviceNumber,
             [SwaggerSchema(Strings.ClientIDDescription, Format = "uint32")][Range(0, 4294967295)] uint ClientID = 0,
@@ -286,7 +297,8 @@ public class FilterWheelSettingsController : ProcessBaseController
         /// <response code="500" examples="Error message describing why the command cannot be processed">Server internal error, check error message</response>
         [HttpPut]
         [Produces(MediaTypeNames.Application.Json)]
-        [ApiExplorerSettings(GroupName = "OmniSim")]        [Route("filterwheel/{DeviceNumber}/interfaceversion")]
+        [ApiExplorerSettings(GroupName = "OmniSim")]
+        [Route("filterwheel/{DeviceNumber}/interfaceversion")]
         public ActionResult<Response> InterfaceVersion(
             [Required][DefaultValue(0)][SwaggerSchema(Strings.DeviceIDDescription, Format = "uint32")][Range(0, 4294967295)] uint DeviceNumber,
             [Required][FromForm][SwaggerSchema("The ASCOM Interface Version, allowed values are 1-3")] System.Int16 InterfaceVersion,

--- a/ASCOM.Alpaca.Simulators/Controllers/FocuserSettingsController.cs
+++ b/ASCOM.Alpaca.Simulators/Controllers/FocuserSettingsController.cs
@@ -17,8 +17,8 @@ namespace ASCOM.Alpaca.Simulators
     [ServiceFilter(typeof(AuthorizationFilter))]
     [ApiController]
     [Route("simulator/v1/")]
-public class FocuserSettingsController : ProcessBaseController
-{
+    public class FocuserSettingsController : ProcessBaseController
+    {
         /// <summary>
         /// OmniSim Only - The ASCOM Interface Version, allowed values are 1-4
         /// </summary>
@@ -33,7 +33,8 @@ public class FocuserSettingsController : ProcessBaseController
         /// <response code="500" examples="Error message describing why the command cannot be processed">Server internal error, check error message</response>
         [HttpGet]
         [Produces(MediaTypeNames.Application.Json)]
-        [ApiExplorerSettings(GroupName = "OmniSim")]        [Route("focuser/{DeviceNumber}/interfaceversion")]
+        [ApiExplorerSettings(GroupName = "OmniSim")]
+        [Route("focuser/{DeviceNumber}/interfaceversion")]
         public ActionResult<ASCOM.Common.Alpaca.IntResponse> InterfaceVersion(
             [Required][DefaultValue(0)][SwaggerSchema(Strings.DeviceIDDescription, Format = "uint32")][Range(0, 4294967295)] uint DeviceNumber,
             [SwaggerSchema(Strings.ClientIDDescription, Format = "uint32")][Range(0, 4294967295)] uint ClientID = 0,
@@ -56,7 +57,8 @@ public class FocuserSettingsController : ProcessBaseController
         /// <response code="500" examples="Error message describing why the command cannot be processed">Server internal error, check error message</response>
         [HttpPut]
         [Produces(MediaTypeNames.Application.Json)]
-        [ApiExplorerSettings(GroupName = "OmniSim")]        [Route("focuser/{DeviceNumber}/interfaceversion")]
+        [ApiExplorerSettings(GroupName = "OmniSim")]
+        [Route("focuser/{DeviceNumber}/interfaceversion")]
         public ActionResult<Response> InterfaceVersion(
             [Required][DefaultValue(0)][SwaggerSchema(Strings.DeviceIDDescription, Format = "uint32")][Range(0, 4294967295)] uint DeviceNumber,
             [Required][FromForm][SwaggerSchema("The ASCOM Interface Version, allowed values are 1-4")] System.Int16 InterfaceVersion,
@@ -79,7 +81,8 @@ public class FocuserSettingsController : ProcessBaseController
         /// <response code="500" examples="Error message describing why the command cannot be processed">Server internal error, check error message</response>
         [HttpGet]
         [Produces(MediaTypeNames.Application.Json)]
-        [ApiExplorerSettings(GroupName = "OmniSim")]        [Route("focuser/{DeviceNumber}/canhalt")]
+        [ApiExplorerSettings(GroupName = "OmniSim")]
+        [Route("focuser/{DeviceNumber}/canhalt")]
         public ActionResult<ASCOM.Common.Alpaca.BoolResponse> CanHalt(
             [Required][DefaultValue(0)][SwaggerSchema(Strings.DeviceIDDescription, Format = "uint32")][Range(0, 4294967295)] uint DeviceNumber,
             [SwaggerSchema(Strings.ClientIDDescription, Format = "uint32")][Range(0, 4294967295)] uint ClientID = 0,
@@ -102,7 +105,8 @@ public class FocuserSettingsController : ProcessBaseController
         /// <response code="500" examples="Error message describing why the command cannot be processed">Server internal error, check error message</response>
         [HttpPut]
         [Produces(MediaTypeNames.Application.Json)]
-        [ApiExplorerSettings(GroupName = "OmniSim")]        [Route("focuser/{DeviceNumber}/canhalt")]
+        [ApiExplorerSettings(GroupName = "OmniSim")]
+        [Route("focuser/{DeviceNumber}/canhalt")]
         public ActionResult<Response> CanHalt(
             [Required][DefaultValue(0)][SwaggerSchema(Strings.DeviceIDDescription, Format = "uint32")][Range(0, 4294967295)] uint DeviceNumber,
             [Required][FromForm][SwaggerSchema("True if the focuser can halt")] System.Boolean CanHalt,
@@ -125,7 +129,8 @@ public class FocuserSettingsController : ProcessBaseController
         /// <response code="500" examples="Error message describing why the command cannot be processed">Server internal error, check error message</response>
         [HttpGet]
         [Produces(MediaTypeNames.Application.Json)]
-        [ApiExplorerSettings(GroupName = "OmniSim")]        [Route("focuser/{DeviceNumber}/tempprobe")]
+        [ApiExplorerSettings(GroupName = "OmniSim")]
+        [Route("focuser/{DeviceNumber}/tempprobe")]
         public ActionResult<ASCOM.Common.Alpaca.BoolResponse> TempProbe(
             [Required][DefaultValue(0)][SwaggerSchema(Strings.DeviceIDDescription, Format = "uint32")][Range(0, 4294967295)] uint DeviceNumber,
             [SwaggerSchema(Strings.ClientIDDescription, Format = "uint32")][Range(0, 4294967295)] uint ClientID = 0,
@@ -148,7 +153,8 @@ public class FocuserSettingsController : ProcessBaseController
         /// <response code="500" examples="Error message describing why the command cannot be processed">Server internal error, check error message</response>
         [HttpPut]
         [Produces(MediaTypeNames.Application.Json)]
-        [ApiExplorerSettings(GroupName = "OmniSim")]        [Route("focuser/{DeviceNumber}/tempprobe")]
+        [ApiExplorerSettings(GroupName = "OmniSim")]
+        [Route("focuser/{DeviceNumber}/tempprobe")]
         public ActionResult<Response> TempProbe(
             [Required][DefaultValue(0)][SwaggerSchema(Strings.DeviceIDDescription, Format = "uint32")][Range(0, 4294967295)] uint DeviceNumber,
             [Required][FromForm][SwaggerSchema("True if the driver has a temperature probe")] System.Boolean TempProbe,
@@ -171,7 +177,8 @@ public class FocuserSettingsController : ProcessBaseController
         /// <response code="500" examples="Error message describing why the command cannot be processed">Server internal error, check error message</response>
         [HttpGet]
         [Produces(MediaTypeNames.Application.Json)]
-        [ApiExplorerSettings(GroupName = "OmniSim")]        [Route("focuser/{DeviceNumber}/synchronous")]
+        [ApiExplorerSettings(GroupName = "OmniSim")]
+        [Route("focuser/{DeviceNumber}/synchronous")]
         public ActionResult<ASCOM.Common.Alpaca.BoolResponse> Synchronous(
             [Required][DefaultValue(0)][SwaggerSchema(Strings.DeviceIDDescription, Format = "uint32")][Range(0, 4294967295)] uint DeviceNumber,
             [SwaggerSchema(Strings.ClientIDDescription, Format = "uint32")][Range(0, 4294967295)] uint ClientID = 0,
@@ -194,7 +201,8 @@ public class FocuserSettingsController : ProcessBaseController
         /// <response code="500" examples="Error message describing why the command cannot be processed">Server internal error, check error message</response>
         [HttpPut]
         [Produces(MediaTypeNames.Application.Json)]
-        [ApiExplorerSettings(GroupName = "OmniSim")]        [Route("focuser/{DeviceNumber}/synchronous")]
+        [ApiExplorerSettings(GroupName = "OmniSim")]
+        [Route("focuser/{DeviceNumber}/synchronous")]
         public ActionResult<Response> Synchronous(
             [Required][DefaultValue(0)][SwaggerSchema(Strings.DeviceIDDescription, Format = "uint32")][Range(0, 4294967295)] uint DeviceNumber,
             [Required][FromForm][SwaggerSchema("True if the focuser moves are synchronous")] System.Boolean Synchronous,
@@ -217,7 +225,8 @@ public class FocuserSettingsController : ProcessBaseController
         /// <response code="500" examples="Error message describing why the command cannot be processed">Server internal error, check error message</response>
         [HttpGet]
         [Produces(MediaTypeNames.Application.Json)]
-        [ApiExplorerSettings(GroupName = "OmniSim")]        [Route("focuser/{DeviceNumber}/canstepsize")]
+        [ApiExplorerSettings(GroupName = "OmniSim")]
+        [Route("focuser/{DeviceNumber}/canstepsize")]
         public ActionResult<ASCOM.Common.Alpaca.BoolResponse> CanStepSize(
             [Required][DefaultValue(0)][SwaggerSchema(Strings.DeviceIDDescription, Format = "uint32")][Range(0, 4294967295)] uint DeviceNumber,
             [SwaggerSchema(Strings.ClientIDDescription, Format = "uint32")][Range(0, 4294967295)] uint ClientID = 0,
@@ -240,7 +249,8 @@ public class FocuserSettingsController : ProcessBaseController
         /// <response code="500" examples="Error message describing why the command cannot be processed">Server internal error, check error message</response>
         [HttpPut]
         [Produces(MediaTypeNames.Application.Json)]
-        [ApiExplorerSettings(GroupName = "OmniSim")]        [Route("focuser/{DeviceNumber}/canstepsize")]
+        [ApiExplorerSettings(GroupName = "OmniSim")]
+        [Route("focuser/{DeviceNumber}/canstepsize")]
         public ActionResult<Response> CanStepSize(
             [Required][DefaultValue(0)][SwaggerSchema(Strings.DeviceIDDescription, Format = "uint32")][Range(0, 4294967295)] uint DeviceNumber,
             [Required][FromForm][SwaggerSchema("True if the driver can report step size")] System.Boolean CanStepSize,
@@ -263,7 +273,8 @@ public class FocuserSettingsController : ProcessBaseController
         /// <response code="500" examples="Error message describing why the command cannot be processed">Server internal error, check error message</response>
         [HttpGet]
         [Produces(MediaTypeNames.Application.Json)]
-        [ApiExplorerSettings(GroupName = "OmniSim")]        [Route("focuser/{DeviceNumber}/tempmax")]
+        [ApiExplorerSettings(GroupName = "OmniSim")]
+        [Route("focuser/{DeviceNumber}/tempmax")]
         public ActionResult<ASCOM.Common.Alpaca.DoubleResponse> TempMax(
             [Required][DefaultValue(0)][SwaggerSchema(Strings.DeviceIDDescription, Format = "uint32")][Range(0, 4294967295)] uint DeviceNumber,
             [SwaggerSchema(Strings.ClientIDDescription, Format = "uint32")][Range(0, 4294967295)] uint ClientID = 0,
@@ -286,7 +297,8 @@ public class FocuserSettingsController : ProcessBaseController
         /// <response code="500" examples="Error message describing why the command cannot be processed">Server internal error, check error message</response>
         [HttpPut]
         [Produces(MediaTypeNames.Application.Json)]
-        [ApiExplorerSettings(GroupName = "OmniSim")]        [Route("focuser/{DeviceNumber}/tempmax")]
+        [ApiExplorerSettings(GroupName = "OmniSim")]
+        [Route("focuser/{DeviceNumber}/tempmax")]
         public ActionResult<Response> TempMax(
             [Required][DefaultValue(0)][SwaggerSchema(Strings.DeviceIDDescription, Format = "uint32")][Range(0, 4294967295)] uint DeviceNumber,
             [Required][FromForm][SwaggerSchema("Maximum simulated temperature")] System.Double TempMax,
@@ -309,7 +321,8 @@ public class FocuserSettingsController : ProcessBaseController
         /// <response code="500" examples="Error message describing why the command cannot be processed">Server internal error, check error message</response>
         [HttpGet]
         [Produces(MediaTypeNames.Application.Json)]
-        [ApiExplorerSettings(GroupName = "OmniSim")]        [Route("focuser/{DeviceNumber}/tempmin")]
+        [ApiExplorerSettings(GroupName = "OmniSim")]
+        [Route("focuser/{DeviceNumber}/tempmin")]
         public ActionResult<ASCOM.Common.Alpaca.DoubleResponse> TempMin(
             [Required][DefaultValue(0)][SwaggerSchema(Strings.DeviceIDDescription, Format = "uint32")][Range(0, 4294967295)] uint DeviceNumber,
             [SwaggerSchema(Strings.ClientIDDescription, Format = "uint32")][Range(0, 4294967295)] uint ClientID = 0,
@@ -332,7 +345,8 @@ public class FocuserSettingsController : ProcessBaseController
         /// <response code="500" examples="Error message describing why the command cannot be processed">Server internal error, check error message</response>
         [HttpPut]
         [Produces(MediaTypeNames.Application.Json)]
-        [ApiExplorerSettings(GroupName = "OmniSim")]        [Route("focuser/{DeviceNumber}/tempmin")]
+        [ApiExplorerSettings(GroupName = "OmniSim")]
+        [Route("focuser/{DeviceNumber}/tempmin")]
         public ActionResult<Response> TempMin(
             [Required][DefaultValue(0)][SwaggerSchema(Strings.DeviceIDDescription, Format = "uint32")][Range(0, 4294967295)] uint DeviceNumber,
             [Required][FromForm][SwaggerSchema("Minimum simulated temperature")] System.Double TempMin,
@@ -355,7 +369,8 @@ public class FocuserSettingsController : ProcessBaseController
         /// <response code="500" examples="Error message describing why the command cannot be processed">Server internal error, check error message</response>
         [HttpGet]
         [Produces(MediaTypeNames.Application.Json)]
-        [ApiExplorerSettings(GroupName = "OmniSim")]        [Route("focuser/{DeviceNumber}/tempperiod")]
+        [ApiExplorerSettings(GroupName = "OmniSim")]
+        [Route("focuser/{DeviceNumber}/tempperiod")]
         public ActionResult<ASCOM.Common.Alpaca.DoubleResponse> TempPeriod(
             [Required][DefaultValue(0)][SwaggerSchema(Strings.DeviceIDDescription, Format = "uint32")][Range(0, 4294967295)] uint DeviceNumber,
             [SwaggerSchema(Strings.ClientIDDescription, Format = "uint32")][Range(0, 4294967295)] uint ClientID = 0,
@@ -378,7 +393,8 @@ public class FocuserSettingsController : ProcessBaseController
         /// <response code="500" examples="Error message describing why the command cannot be processed">Server internal error, check error message</response>
         [HttpPut]
         [Produces(MediaTypeNames.Application.Json)]
-        [ApiExplorerSettings(GroupName = "OmniSim")]        [Route("focuser/{DeviceNumber}/tempperiod")]
+        [ApiExplorerSettings(GroupName = "OmniSim")]
+        [Route("focuser/{DeviceNumber}/tempperiod")]
         public ActionResult<Response> TempPeriod(
             [Required][DefaultValue(0)][SwaggerSchema(Strings.DeviceIDDescription, Format = "uint32")][Range(0, 4294967295)] uint DeviceNumber,
             [Required][FromForm][SwaggerSchema("Period to use for temperature changes (seconds)")] System.Double TempPeriod,
@@ -401,7 +417,8 @@ public class FocuserSettingsController : ProcessBaseController
         /// <response code="500" examples="Error message describing why the command cannot be processed">Server internal error, check error message</response>
         [HttpGet]
         [Produces(MediaTypeNames.Application.Json)]
-        [ApiExplorerSettings(GroupName = "OmniSim")]        [Route("focuser/{DeviceNumber}/tempsteps")]
+        [ApiExplorerSettings(GroupName = "OmniSim")]
+        [Route("focuser/{DeviceNumber}/tempsteps")]
         public ActionResult<ASCOM.Common.Alpaca.IntResponse> TempSteps(
             [Required][DefaultValue(0)][SwaggerSchema(Strings.DeviceIDDescription, Format = "uint32")][Range(0, 4294967295)] uint DeviceNumber,
             [SwaggerSchema(Strings.ClientIDDescription, Format = "uint32")][Range(0, 4294967295)] uint ClientID = 0,
@@ -424,7 +441,8 @@ public class FocuserSettingsController : ProcessBaseController
         /// <response code="500" examples="Error message describing why the command cannot be processed">Server internal error, check error message</response>
         [HttpPut]
         [Produces(MediaTypeNames.Application.Json)]
-        [ApiExplorerSettings(GroupName = "OmniSim")]        [Route("focuser/{DeviceNumber}/tempsteps")]
+        [ApiExplorerSettings(GroupName = "OmniSim")]
+        [Route("focuser/{DeviceNumber}/tempsteps")]
         public ActionResult<Response> TempSteps(
             [Required][DefaultValue(0)][SwaggerSchema(Strings.DeviceIDDescription, Format = "uint32")][Range(0, 4294967295)] uint DeviceNumber,
             [Required][FromForm][SwaggerSchema("How many steps per temp comp action")] System.Int32 TempSteps,
@@ -447,7 +465,8 @@ public class FocuserSettingsController : ProcessBaseController
         /// <response code="500" examples="Error message describing why the command cannot be processed">Server internal error, check error message</response>
         [HttpGet]
         [Produces(MediaTypeNames.Application.Json)]
-        [ApiExplorerSettings(GroupName = "OmniSim")]        [Route("focuser/{DeviceNumber}/settletime")]
+        [ApiExplorerSettings(GroupName = "OmniSim")]
+        [Route("focuser/{DeviceNumber}/settletime")]
         public ActionResult<ASCOM.Common.Alpaca.IntResponse> SettleTime(
             [Required][DefaultValue(0)][SwaggerSchema(Strings.DeviceIDDescription, Format = "uint32")][Range(0, 4294967295)] uint DeviceNumber,
             [SwaggerSchema(Strings.ClientIDDescription, Format = "uint32")][Range(0, 4294967295)] uint ClientID = 0,
@@ -470,7 +489,8 @@ public class FocuserSettingsController : ProcessBaseController
         /// <response code="500" examples="Error message describing why the command cannot be processed">Server internal error, check error message</response>
         [HttpPut]
         [Produces(MediaTypeNames.Application.Json)]
-        [ApiExplorerSettings(GroupName = "OmniSim")]        [Route("focuser/{DeviceNumber}/settletime")]
+        [ApiExplorerSettings(GroupName = "OmniSim")]
+        [Route("focuser/{DeviceNumber}/settletime")]
         public ActionResult<Response> SettleTime(
             [Required][DefaultValue(0)][SwaggerSchema(Strings.DeviceIDDescription, Format = "uint32")][Range(0, 4294967295)] uint DeviceNumber,
             [Required][FromForm][SwaggerSchema("Move settle time")] System.Int32 SettleTime,
@@ -493,7 +513,8 @@ public class FocuserSettingsController : ProcessBaseController
         /// <response code="500" examples="Error message describing why the command cannot be processed">Server internal error, check error message</response>
         [HttpGet]
         [Produces(MediaTypeNames.Application.Json)]
-        [ApiExplorerSettings(GroupName = "OmniSim")]        [Route("focuser/{DeviceNumber}/absolute")]
+        [ApiExplorerSettings(GroupName = "OmniSim")]
+        [Route("focuser/{DeviceNumber}/absolute")]
         public ActionResult<ASCOM.Common.Alpaca.BoolResponse> Absolute(
             [Required][DefaultValue(0)][SwaggerSchema(Strings.DeviceIDDescription, Format = "uint32")][Range(0, 4294967295)] uint DeviceNumber,
             [SwaggerSchema(Strings.ClientIDDescription, Format = "uint32")][Range(0, 4294967295)] uint ClientID = 0,
@@ -516,7 +537,8 @@ public class FocuserSettingsController : ProcessBaseController
         /// <response code="500" examples="Error message describing why the command cannot be processed">Server internal error, check error message</response>
         [HttpPut]
         [Produces(MediaTypeNames.Application.Json)]
-        [ApiExplorerSettings(GroupName = "OmniSim")]        [Route("focuser/{DeviceNumber}/absolute")]
+        [ApiExplorerSettings(GroupName = "OmniSim")]
+        [Route("focuser/{DeviceNumber}/absolute")]
         public ActionResult<Response> Absolute(
             [Required][DefaultValue(0)][SwaggerSchema(Strings.DeviceIDDescription, Format = "uint32")][Range(0, 4294967295)] uint DeviceNumber,
             [Required][FromForm][SwaggerSchema("True if the focuser is an absolute focuser")] System.Boolean Absolute,
@@ -539,7 +561,8 @@ public class FocuserSettingsController : ProcessBaseController
         /// <response code="500" examples="Error message describing why the command cannot be processed">Server internal error, check error message</response>
         [HttpGet]
         [Produces(MediaTypeNames.Application.Json)]
-        [ApiExplorerSettings(GroupName = "OmniSim")]        [Route("focuser/{DeviceNumber}/maxincrement")]
+        [ApiExplorerSettings(GroupName = "OmniSim")]
+        [Route("focuser/{DeviceNumber}/maxincrement")]
         public ActionResult<ASCOM.Common.Alpaca.IntResponse> MaxIncrement(
             [Required][DefaultValue(0)][SwaggerSchema(Strings.DeviceIDDescription, Format = "uint32")][Range(0, 4294967295)] uint DeviceNumber,
             [SwaggerSchema(Strings.ClientIDDescription, Format = "uint32")][Range(0, 4294967295)] uint ClientID = 0,
@@ -562,7 +585,8 @@ public class FocuserSettingsController : ProcessBaseController
         /// <response code="500" examples="Error message describing why the command cannot be processed">Server internal error, check error message</response>
         [HttpPut]
         [Produces(MediaTypeNames.Application.Json)]
-        [ApiExplorerSettings(GroupName = "OmniSim")]        [Route("focuser/{DeviceNumber}/maxincrement")]
+        [ApiExplorerSettings(GroupName = "OmniSim")]
+        [Route("focuser/{DeviceNumber}/maxincrement")]
         public ActionResult<Response> MaxIncrement(
             [Required][DefaultValue(0)][SwaggerSchema(Strings.DeviceIDDescription, Format = "uint32")][Range(0, 4294967295)] uint DeviceNumber,
             [Required][FromForm][SwaggerSchema("The Maximum Increment for moves")] System.Int32 MaxIncrement,
@@ -585,7 +609,8 @@ public class FocuserSettingsController : ProcessBaseController
         /// <response code="500" examples="Error message describing why the command cannot be processed">Server internal error, check error message</response>
         [HttpGet]
         [Produces(MediaTypeNames.Application.Json)]
-        [ApiExplorerSettings(GroupName = "OmniSim")]        [Route("focuser/{DeviceNumber}/maxstep")]
+        [ApiExplorerSettings(GroupName = "OmniSim")]
+        [Route("focuser/{DeviceNumber}/maxstep")]
         public ActionResult<ASCOM.Common.Alpaca.IntResponse> MaxStep(
             [Required][DefaultValue(0)][SwaggerSchema(Strings.DeviceIDDescription, Format = "uint32")][Range(0, 4294967295)] uint DeviceNumber,
             [SwaggerSchema(Strings.ClientIDDescription, Format = "uint32")][Range(0, 4294967295)] uint ClientID = 0,
@@ -608,7 +633,8 @@ public class FocuserSettingsController : ProcessBaseController
         /// <response code="500" examples="Error message describing why the command cannot be processed">Server internal error, check error message</response>
         [HttpPut]
         [Produces(MediaTypeNames.Application.Json)]
-        [ApiExplorerSettings(GroupName = "OmniSim")]        [Route("focuser/{DeviceNumber}/maxstep")]
+        [ApiExplorerSettings(GroupName = "OmniSim")]
+        [Route("focuser/{DeviceNumber}/maxstep")]
         public ActionResult<Response> MaxStep(
             [Required][DefaultValue(0)][SwaggerSchema(Strings.DeviceIDDescription, Format = "uint32")][Range(0, 4294967295)] uint DeviceNumber,
             [Required][FromForm][SwaggerSchema("The Max Step for moves")] System.Int32 MaxStep,
@@ -631,7 +657,8 @@ public class FocuserSettingsController : ProcessBaseController
         /// <response code="500" examples="Error message describing why the command cannot be processed">Server internal error, check error message</response>
         [HttpGet]
         [Produces(MediaTypeNames.Application.Json)]
-        [ApiExplorerSettings(GroupName = "OmniSim")]        [Route("focuser/{DeviceNumber}/position")]
+        [ApiExplorerSettings(GroupName = "OmniSim")]
+        [Route("focuser/{DeviceNumber}/position")]
         public ActionResult<ASCOM.Common.Alpaca.IntResponse> Position(
             [Required][DefaultValue(0)][SwaggerSchema(Strings.DeviceIDDescription, Format = "uint32")][Range(0, 4294967295)] uint DeviceNumber,
             [SwaggerSchema(Strings.ClientIDDescription, Format = "uint32")][Range(0, 4294967295)] uint ClientID = 0,
@@ -654,7 +681,8 @@ public class FocuserSettingsController : ProcessBaseController
         /// <response code="500" examples="Error message describing why the command cannot be processed">Server internal error, check error message</response>
         [HttpPut]
         [Produces(MediaTypeNames.Application.Json)]
-        [ApiExplorerSettings(GroupName = "OmniSim")]        [Route("focuser/{DeviceNumber}/position")]
+        [ApiExplorerSettings(GroupName = "OmniSim")]
+        [Route("focuser/{DeviceNumber}/position")]
         public ActionResult<Response> Position(
             [Required][DefaultValue(0)][SwaggerSchema(Strings.DeviceIDDescription, Format = "uint32")][Range(0, 4294967295)] uint DeviceNumber,
             [Required][FromForm][SwaggerSchema("The starting position")] System.Int32 Position,
@@ -677,7 +705,8 @@ public class FocuserSettingsController : ProcessBaseController
         /// <response code="500" examples="Error message describing why the command cannot be processed">Server internal error, check error message</response>
         [HttpGet]
         [Produces(MediaTypeNames.Application.Json)]
-        [ApiExplorerSettings(GroupName = "OmniSim")]        [Route("focuser/{DeviceNumber}/stepsize")]
+        [ApiExplorerSettings(GroupName = "OmniSim")]
+        [Route("focuser/{DeviceNumber}/stepsize")]
         public ActionResult<ASCOM.Common.Alpaca.IntResponse> StepSize(
             [Required][DefaultValue(0)][SwaggerSchema(Strings.DeviceIDDescription, Format = "uint32")][Range(0, 4294967295)] uint DeviceNumber,
             [SwaggerSchema(Strings.ClientIDDescription, Format = "uint32")][Range(0, 4294967295)] uint ClientID = 0,
@@ -700,7 +729,8 @@ public class FocuserSettingsController : ProcessBaseController
         /// <response code="500" examples="Error message describing why the command cannot be processed">Server internal error, check error message</response>
         [HttpPut]
         [Produces(MediaTypeNames.Application.Json)]
-        [ApiExplorerSettings(GroupName = "OmniSim")]        [Route("focuser/{DeviceNumber}/stepsize")]
+        [ApiExplorerSettings(GroupName = "OmniSim")]
+        [Route("focuser/{DeviceNumber}/stepsize")]
         public ActionResult<Response> StepSize(
             [Required][DefaultValue(0)][SwaggerSchema(Strings.DeviceIDDescription, Format = "uint32")][Range(0, 4294967295)] uint DeviceNumber,
             [Required][FromForm][SwaggerSchema("The focuser step size (microns)")] System.Int32 StepSize,
@@ -723,7 +753,8 @@ public class FocuserSettingsController : ProcessBaseController
         /// <response code="500" examples="Error message describing why the command cannot be processed">Server internal error, check error message</response>
         [HttpGet]
         [Produces(MediaTypeNames.Application.Json)]
-        [ApiExplorerSettings(GroupName = "OmniSim")]        [Route("focuser/{DeviceNumber}/tempcomp")]
+        [ApiExplorerSettings(GroupName = "OmniSim")]
+        [Route("focuser/{DeviceNumber}/tempcomp")]
         public ActionResult<ASCOM.Common.Alpaca.BoolResponse> TempComp(
             [Required][DefaultValue(0)][SwaggerSchema(Strings.DeviceIDDescription, Format = "uint32")][Range(0, 4294967295)] uint DeviceNumber,
             [SwaggerSchema(Strings.ClientIDDescription, Format = "uint32")][Range(0, 4294967295)] uint ClientID = 0,
@@ -746,7 +777,8 @@ public class FocuserSettingsController : ProcessBaseController
         /// <response code="500" examples="Error message describing why the command cannot be processed">Server internal error, check error message</response>
         [HttpPut]
         [Produces(MediaTypeNames.Application.Json)]
-        [ApiExplorerSettings(GroupName = "OmniSim")]        [Route("focuser/{DeviceNumber}/tempcomp")]
+        [ApiExplorerSettings(GroupName = "OmniSim")]
+        [Route("focuser/{DeviceNumber}/tempcomp")]
         public ActionResult<Response> TempComp(
             [Required][DefaultValue(0)][SwaggerSchema(Strings.DeviceIDDescription, Format = "uint32")][Range(0, 4294967295)] uint DeviceNumber,
             [Required][FromForm][SwaggerSchema("Temp Comp State")] System.Boolean TempComp,
@@ -769,7 +801,8 @@ public class FocuserSettingsController : ProcessBaseController
         /// <response code="500" examples="Error message describing why the command cannot be processed">Server internal error, check error message</response>
         [HttpGet]
         [Produces(MediaTypeNames.Application.Json)]
-        [ApiExplorerSettings(GroupName = "OmniSim")]        [Route("focuser/{DeviceNumber}/tempcompavailable")]
+        [ApiExplorerSettings(GroupName = "OmniSim")]
+        [Route("focuser/{DeviceNumber}/tempcompavailable")]
         public ActionResult<ASCOM.Common.Alpaca.BoolResponse> TempCompAvailable(
             [Required][DefaultValue(0)][SwaggerSchema(Strings.DeviceIDDescription, Format = "uint32")][Range(0, 4294967295)] uint DeviceNumber,
             [SwaggerSchema(Strings.ClientIDDescription, Format = "uint32")][Range(0, 4294967295)] uint ClientID = 0,
@@ -792,7 +825,8 @@ public class FocuserSettingsController : ProcessBaseController
         /// <response code="500" examples="Error message describing why the command cannot be processed">Server internal error, check error message</response>
         [HttpPut]
         [Produces(MediaTypeNames.Application.Json)]
-        [ApiExplorerSettings(GroupName = "OmniSim")]        [Route("focuser/{DeviceNumber}/tempcompavailable")]
+        [ApiExplorerSettings(GroupName = "OmniSim")]
+        [Route("focuser/{DeviceNumber}/tempcompavailable")]
         public ActionResult<Response> TempCompAvailable(
             [Required][DefaultValue(0)][SwaggerSchema(Strings.DeviceIDDescription, Format = "uint32")][Range(0, 4294967295)] uint DeviceNumber,
             [Required][FromForm][SwaggerSchema("True if the driver supports temp comp")] System.Boolean TempCompAvailable,
@@ -815,7 +849,8 @@ public class FocuserSettingsController : ProcessBaseController
         /// <response code="500" examples="Error message describing why the command cannot be processed">Server internal error, check error message</response>
         [HttpGet]
         [Produces(MediaTypeNames.Application.Json)]
-        [ApiExplorerSettings(GroupName = "OmniSim")]        [Route("focuser/{DeviceNumber}/temperature")]
+        [ApiExplorerSettings(GroupName = "OmniSim")]
+        [Route("focuser/{DeviceNumber}/temperature")]
         public ActionResult<ASCOM.Common.Alpaca.DoubleResponse> Temperature(
             [Required][DefaultValue(0)][SwaggerSchema(Strings.DeviceIDDescription, Format = "uint32")][Range(0, 4294967295)] uint DeviceNumber,
             [SwaggerSchema(Strings.ClientIDDescription, Format = "uint32")][Range(0, 4294967295)] uint ClientID = 0,
@@ -838,7 +873,8 @@ public class FocuserSettingsController : ProcessBaseController
         /// <response code="500" examples="Error message describing why the command cannot be processed">Server internal error, check error message</response>
         [HttpPut]
         [Produces(MediaTypeNames.Application.Json)]
-        [ApiExplorerSettings(GroupName = "OmniSim")]        [Route("focuser/{DeviceNumber}/temperature")]
+        [ApiExplorerSettings(GroupName = "OmniSim")]
+        [Route("focuser/{DeviceNumber}/temperature")]
         public ActionResult<Response> Temperature(
             [Required][DefaultValue(0)][SwaggerSchema(Strings.DeviceIDDescription, Format = "uint32")][Range(0, 4294967295)] uint DeviceNumber,
             [Required][FromForm][SwaggerSchema("Starting Temperature")] System.Double Temperature,

--- a/ASCOM.Alpaca.Simulators/Controllers/RotatorSettingsController.cs
+++ b/ASCOM.Alpaca.Simulators/Controllers/RotatorSettingsController.cs
@@ -17,8 +17,8 @@ namespace ASCOM.Alpaca.Simulators
     [ServiceFilter(typeof(AuthorizationFilter))]
     [ApiController]
     [Route("simulator/v1/")]
-public class RotatorSettingsController : ProcessBaseController
-{
+    public class RotatorSettingsController : ProcessBaseController
+    {
         /// <summary>
         /// OmniSim Only - The ASCOM Interface Version, allowed values are 1-4
         /// </summary>
@@ -33,7 +33,8 @@ public class RotatorSettingsController : ProcessBaseController
         /// <response code="500" examples="Error message describing why the command cannot be processed">Server internal error, check error message</response>
         [HttpGet]
         [Produces(MediaTypeNames.Application.Json)]
-        [ApiExplorerSettings(GroupName = "OmniSim")]        [Route("rotator/{DeviceNumber}/interfaceversion")]
+        [ApiExplorerSettings(GroupName = "OmniSim")]
+        [Route("rotator/{DeviceNumber}/interfaceversion")]
         public ActionResult<ASCOM.Common.Alpaca.IntResponse> InterfaceVersion(
             [Required][DefaultValue(0)][SwaggerSchema(Strings.DeviceIDDescription, Format = "uint32")][Range(0, 4294967295)] uint DeviceNumber,
             [SwaggerSchema(Strings.ClientIDDescription, Format = "uint32")][Range(0, 4294967295)] uint ClientID = 0,
@@ -56,7 +57,8 @@ public class RotatorSettingsController : ProcessBaseController
         /// <response code="500" examples="Error message describing why the command cannot be processed">Server internal error, check error message</response>
         [HttpPut]
         [Produces(MediaTypeNames.Application.Json)]
-        [ApiExplorerSettings(GroupName = "OmniSim")]        [Route("rotator/{DeviceNumber}/interfaceversion")]
+        [ApiExplorerSettings(GroupName = "OmniSim")]
+        [Route("rotator/{DeviceNumber}/interfaceversion")]
         public ActionResult<Response> InterfaceVersion(
             [Required][DefaultValue(0)][SwaggerSchema(Strings.DeviceIDDescription, Format = "uint32")][Range(0, 4294967295)] uint DeviceNumber,
             [Required][FromForm][SwaggerSchema("The ASCOM Interface Version, allowed values are 1-4")] System.Int16 InterfaceVersion,
@@ -79,7 +81,8 @@ public class RotatorSettingsController : ProcessBaseController
         /// <response code="500" examples="Error message describing why the command cannot be processed">Server internal error, check error message</response>
         [HttpGet]
         [Produces(MediaTypeNames.Application.Json)]
-        [ApiExplorerSettings(GroupName = "OmniSim")]        [Route("rotator/{DeviceNumber}/position")]
+        [ApiExplorerSettings(GroupName = "OmniSim")]
+        [Route("rotator/{DeviceNumber}/position")]
         public ActionResult<ASCOM.Common.Alpaca.DoubleResponse> Position(
             [Required][DefaultValue(0)][SwaggerSchema(Strings.DeviceIDDescription, Format = "uint32")][Range(0, 4294967295)] uint DeviceNumber,
             [SwaggerSchema(Strings.ClientIDDescription, Format = "uint32")][Range(0, 4294967295)] uint ClientID = 0,
@@ -102,7 +105,8 @@ public class RotatorSettingsController : ProcessBaseController
         /// <response code="500" examples="Error message describing why the command cannot be processed">Server internal error, check error message</response>
         [HttpPut]
         [Produces(MediaTypeNames.Application.Json)]
-        [ApiExplorerSettings(GroupName = "OmniSim")]        [Route("rotator/{DeviceNumber}/position")]
+        [ApiExplorerSettings(GroupName = "OmniSim")]
+        [Route("rotator/{DeviceNumber}/position")]
         public ActionResult<Response> Position(
             [Required][DefaultValue(0)][SwaggerSchema(Strings.DeviceIDDescription, Format = "uint32")][Range(0, 4294967295)] uint DeviceNumber,
             [Required][FromForm][SwaggerSchema("The starting position 0 to 359.999")] System.Single Position,
@@ -125,7 +129,8 @@ public class RotatorSettingsController : ProcessBaseController
         /// <response code="500" examples="Error message describing why the command cannot be processed">Server internal error, check error message</response>
         [HttpGet]
         [Produces(MediaTypeNames.Application.Json)]
-        [ApiExplorerSettings(GroupName = "OmniSim")]        [Route("rotator/{DeviceNumber}/rotationrate")]
+        [ApiExplorerSettings(GroupName = "OmniSim")]
+        [Route("rotator/{DeviceNumber}/rotationrate")]
         public ActionResult<ASCOM.Common.Alpaca.DoubleResponse> RotationRate(
             [Required][DefaultValue(0)][SwaggerSchema(Strings.DeviceIDDescription, Format = "uint32")][Range(0, 4294967295)] uint DeviceNumber,
             [SwaggerSchema(Strings.ClientIDDescription, Format = "uint32")][Range(0, 4294967295)] uint ClientID = 0,
@@ -148,7 +153,8 @@ public class RotatorSettingsController : ProcessBaseController
         /// <response code="500" examples="Error message describing why the command cannot be processed">Server internal error, check error message</response>
         [HttpPut]
         [Produces(MediaTypeNames.Application.Json)]
-        [ApiExplorerSettings(GroupName = "OmniSim")]        [Route("rotator/{DeviceNumber}/rotationrate")]
+        [ApiExplorerSettings(GroupName = "OmniSim")]
+        [Route("rotator/{DeviceNumber}/rotationrate")]
         public ActionResult<Response> RotationRate(
             [Required][DefaultValue(0)][SwaggerSchema(Strings.DeviceIDDescription, Format = "uint32")][Range(0, 4294967295)] uint DeviceNumber,
             [Required][FromForm][SwaggerSchema("The rotation rate in degrees per second")] System.Double RotationRate,
@@ -171,7 +177,8 @@ public class RotatorSettingsController : ProcessBaseController
         /// <response code="500" examples="Error message describing why the command cannot be processed">Server internal error, check error message</response>
         [HttpGet]
         [Produces(MediaTypeNames.Application.Json)]
-        [ApiExplorerSettings(GroupName = "OmniSim")]        [Route("rotator/{DeviceNumber}/canreverse")]
+        [ApiExplorerSettings(GroupName = "OmniSim")]
+        [Route("rotator/{DeviceNumber}/canreverse")]
         public ActionResult<ASCOM.Common.Alpaca.BoolResponse> CanReverse(
             [Required][DefaultValue(0)][SwaggerSchema(Strings.DeviceIDDescription, Format = "uint32")][Range(0, 4294967295)] uint DeviceNumber,
             [SwaggerSchema(Strings.ClientIDDescription, Format = "uint32")][Range(0, 4294967295)] uint ClientID = 0,
@@ -194,7 +201,8 @@ public class RotatorSettingsController : ProcessBaseController
         /// <response code="500" examples="Error message describing why the command cannot be processed">Server internal error, check error message</response>
         [HttpPut]
         [Produces(MediaTypeNames.Application.Json)]
-        [ApiExplorerSettings(GroupName = "OmniSim")]        [Route("rotator/{DeviceNumber}/canreverse")]
+        [ApiExplorerSettings(GroupName = "OmniSim")]
+        [Route("rotator/{DeviceNumber}/canreverse")]
         public ActionResult<Response> CanReverse(
             [Required][DefaultValue(0)][SwaggerSchema(Strings.DeviceIDDescription, Format = "uint32")][Range(0, 4294967295)] uint DeviceNumber,
             [Required][FromForm][SwaggerSchema("True if the rotator can reverse")] System.Boolean CanReverse,
@@ -217,7 +225,8 @@ public class RotatorSettingsController : ProcessBaseController
         /// <response code="500" examples="Error message describing why the command cannot be processed">Server internal error, check error message</response>
         [HttpGet]
         [Produces(MediaTypeNames.Application.Json)]
-        [ApiExplorerSettings(GroupName = "OmniSim")]        [Route("rotator/{DeviceNumber}/reverse")]
+        [ApiExplorerSettings(GroupName = "OmniSim")]
+        [Route("rotator/{DeviceNumber}/reverse")]
         public ActionResult<ASCOM.Common.Alpaca.BoolResponse> Reverse(
             [Required][DefaultValue(0)][SwaggerSchema(Strings.DeviceIDDescription, Format = "uint32")][Range(0, 4294967295)] uint DeviceNumber,
             [SwaggerSchema(Strings.ClientIDDescription, Format = "uint32")][Range(0, 4294967295)] uint ClientID = 0,
@@ -240,7 +249,8 @@ public class RotatorSettingsController : ProcessBaseController
         /// <response code="500" examples="Error message describing why the command cannot be processed">Server internal error, check error message</response>
         [HttpPut]
         [Produces(MediaTypeNames.Application.Json)]
-        [ApiExplorerSettings(GroupName = "OmniSim")]        [Route("rotator/{DeviceNumber}/reverse")]
+        [ApiExplorerSettings(GroupName = "OmniSim")]
+        [Route("rotator/{DeviceNumber}/reverse")]
         public ActionResult<Response> Reverse(
             [Required][DefaultValue(0)][SwaggerSchema(Strings.DeviceIDDescription, Format = "uint32")][Range(0, 4294967295)] uint DeviceNumber,
             [Required][FromForm][SwaggerSchema("True if the rotator is reversed")] System.Boolean Reverse,
@@ -263,7 +273,8 @@ public class RotatorSettingsController : ProcessBaseController
         /// <response code="500" examples="Error message describing why the command cannot be processed">Server internal error, check error message</response>
         [HttpGet]
         [Produces(MediaTypeNames.Application.Json)]
-        [ApiExplorerSettings(GroupName = "OmniSim")]        [Route("rotator/{DeviceNumber}/syncoffset")]
+        [ApiExplorerSettings(GroupName = "OmniSim")]
+        [Route("rotator/{DeviceNumber}/syncoffset")]
         public ActionResult<ASCOM.Common.Alpaca.DoubleResponse> SyncOffset(
             [Required][DefaultValue(0)][SwaggerSchema(Strings.DeviceIDDescription, Format = "uint32")][Range(0, 4294967295)] uint DeviceNumber,
             [SwaggerSchema(Strings.ClientIDDescription, Format = "uint32")][Range(0, 4294967295)] uint ClientID = 0,
@@ -286,7 +297,8 @@ public class RotatorSettingsController : ProcessBaseController
         /// <response code="500" examples="Error message describing why the command cannot be processed">Server internal error, check error message</response>
         [HttpPut]
         [Produces(MediaTypeNames.Application.Json)]
-        [ApiExplorerSettings(GroupName = "OmniSim")]        [Route("rotator/{DeviceNumber}/syncoffset")]
+        [ApiExplorerSettings(GroupName = "OmniSim")]
+        [Route("rotator/{DeviceNumber}/syncoffset")]
         public ActionResult<Response> SyncOffset(
             [Required][DefaultValue(0)][SwaggerSchema(Strings.DeviceIDDescription, Format = "uint32")][Range(0, 4294967295)] uint DeviceNumber,
             [Required][FromForm][SwaggerSchema("The current Sync Offset, 0 to 359.999")] System.Single SyncOffset,

--- a/ASCOM.Alpaca.Simulators/Controllers/SetupController.cs
+++ b/ASCOM.Alpaca.Simulators/Controllers/SetupController.cs
@@ -8,12 +8,12 @@ using ASCOM.Common;
 using Octokit;
 using System.Xml;
 using OmniSim.BaseDriver;
-using static System.Runtime.InteropServices.JavaScript.JSType;
 using Microsoft.AspNetCore.Mvc.RazorPages;
 using System.IO;
 
 namespace ASCOM.Alpaca.Simulators.Controllers
 {
+    [ApiExplorerSettings(GroupName = "AlpacaSetup")]
     public class SetupController : Controller
     {
         /// <summary>
@@ -29,7 +29,6 @@ namespace ASCOM.Alpaca.Simulators.Controllers
         /// <response code="500" examples="Error message describing why the command cannot be processed">Server internal error, check error message</response>
         [HttpGet]
         [Produces(MediaTypeNames.Text.Html)]
-        [ApiExplorerSettings(GroupName = "Alpaca")]
         [FeatureGate("HideAlpacaUI")]
         [Route("/setup")]
         public ActionResult<string> ServerSetup([Required][DefaultValue(0)][SwaggerSchema(Strings.DeviceIDDescription, Format = "uint32")][Range(0, 4294967295)] uint DeviceNumber)
@@ -50,7 +49,6 @@ namespace ASCOM.Alpaca.Simulators.Controllers
         /// <response code="500" examples="Error message describing why the command cannot be processed">Server internal error, check error message</response>
         [HttpGet]
         [Produces(MediaTypeNames.Text.Html)]
-        [ApiExplorerSettings(GroupName = "Alpaca")]
         [FeatureGate("HideAlpacaUI")]
         [Route("/setup/v1/camera/{DeviceNumber}/setup")]
         public ActionResult<string> CameraSetup([Required][DefaultValue(0)][SwaggerSchema(Strings.DeviceIDDescription, Format = "uint32")][Range(0, 4294967295)] uint DeviceNumber)
@@ -71,7 +69,6 @@ namespace ASCOM.Alpaca.Simulators.Controllers
         /// <response code="500" examples="Error message describing why the command cannot be processed">Server internal error, check error message</response>
         [HttpGet]
         [Produces(MediaTypeNames.Text.Html)]
-        [ApiExplorerSettings(GroupName = "Alpaca")]
         [FeatureGate("HideAlpacaUI")]
         [Route("/setup/v1/covercalibrator/{DeviceNumber}/setup")]
         public ActionResult<string> CoverCalibratorSetup([Required][DefaultValue(0)][SwaggerSchema(Strings.DeviceIDDescription, Format = "uint32")][Range(0, 4294967295)] uint DeviceNumber)
@@ -92,7 +89,6 @@ namespace ASCOM.Alpaca.Simulators.Controllers
         /// <response code="500" examples="Error message describing why the command cannot be processed">Server internal error, check error message</response>
         [HttpGet]
         [Produces(MediaTypeNames.Text.Html)]
-        [ApiExplorerSettings(GroupName = "Alpaca")]
         [FeatureGate("HideAlpacaUI")]
         [Route("/setup/v1/dome/{DeviceNumber}/setup")]
         public ActionResult<string> DomeSetup([Required][DefaultValue(0)][SwaggerSchema(Strings.DeviceIDDescription, Format = "uint32")][Range(0, 4294967295)] uint DeviceNumber)
@@ -113,7 +109,6 @@ namespace ASCOM.Alpaca.Simulators.Controllers
         /// <response code="500" examples="Error message describing why the command cannot be processed">Server internal error, check error message</response>
         [HttpGet]
         [Produces(MediaTypeNames.Text.Html)]
-        [ApiExplorerSettings(GroupName = "Alpaca")]
         [FeatureGate("HideAlpacaUI")]
         [Route("/setup/v1/filterwheel/{DeviceNumber}/setup")]
         public ActionResult<string> FilterWheelSetup([Required][DefaultValue(0)][SwaggerSchema(Strings.DeviceIDDescription, Format = "uint32")][Range(0, 4294967295)] uint DeviceNumber)
@@ -134,7 +129,6 @@ namespace ASCOM.Alpaca.Simulators.Controllers
         /// <response code="500" examples="Error message describing why the command cannot be processed">Server internal error, check error message</response>
         [HttpGet]
         [Produces(MediaTypeNames.Text.Html)]
-        [ApiExplorerSettings(GroupName = "Alpaca")]
         [FeatureGate("HideAlpacaUI")]
         [Route("/setup/v1/focuser/{DeviceNumber}/setup")]
         public ActionResult<string> FocuserSetup([Required][DefaultValue(0)][SwaggerSchema(Strings.DeviceIDDescription, Format = "uint32")][Range(0, 4294967295)] uint DeviceNumber)
@@ -155,7 +149,6 @@ namespace ASCOM.Alpaca.Simulators.Controllers
         /// <response code="500" examples="Error message describing why the command cannot be processed">Server internal error, check error message</response>
         [HttpGet]
         [Produces(MediaTypeNames.Text.Html)]
-        [ApiExplorerSettings(GroupName = "Alpaca")]
         [FeatureGate("HideAlpacaUI")]
         [Route("/setup/v1/observingconditions/{DeviceNumber}/setup")]
         public ActionResult<string> ObservingConditionsSetup([Required][DefaultValue(0)][SwaggerSchema(Strings.DeviceIDDescription, Format = "uint32")][Range(0, 4294967295)] uint DeviceNumber)
@@ -176,7 +169,6 @@ namespace ASCOM.Alpaca.Simulators.Controllers
         /// <response code="500" examples="Error message describing why the command cannot be processed">Server internal error, check error message</response>
         [HttpGet]
         [Produces(MediaTypeNames.Text.Html)]
-        [ApiExplorerSettings(GroupName = "Alpaca")]
         [FeatureGate("HideAlpacaUI")]
         [Route("/setup/v1/rotator/{DeviceNumber}/setup")]
         public ActionResult<string> RotatorSetup([Required][DefaultValue(0)][SwaggerSchema(Strings.DeviceIDDescription, Format = "uint32")][Range(0, 4294967295)] uint DeviceNumber)
@@ -197,7 +189,6 @@ namespace ASCOM.Alpaca.Simulators.Controllers
         /// <response code="500" examples="Error message describing why the command cannot be processed">Server internal error, check error message</response>
         [HttpGet]
         [Produces(MediaTypeNames.Text.Html)]
-        [ApiExplorerSettings(GroupName = "Alpaca")]
         [FeatureGate("HideAlpacaUI")]
         [Route("/setup/v1/safetymonitor/{DeviceNumber}/setup")]
         public ActionResult<string> SafetyMonitorSetup([Required][DefaultValue(0)][SwaggerSchema(Strings.DeviceIDDescription, Format = "uint32")][Range(0, 4294967295)] uint DeviceNumber)
@@ -218,7 +209,6 @@ namespace ASCOM.Alpaca.Simulators.Controllers
         /// <response code="500" examples="Error message describing why the command cannot be processed">Server internal error, check error message</response>
         [HttpGet]
         [Produces(MediaTypeNames.Text.Html)]
-        [ApiExplorerSettings(GroupName = "Alpaca")]
         [FeatureGate("HideAlpacaUI")]
         [Route("/setup/v1/switch/{DeviceNumber}/setup")]
         public ActionResult<string> SwitchSetup([Required][DefaultValue(0)][SwaggerSchema(Strings.DeviceIDDescription, Format = "uint32")][Range(0, 4294967295)] uint DeviceNumber)
@@ -239,7 +229,6 @@ namespace ASCOM.Alpaca.Simulators.Controllers
         /// <response code="500" examples="Error message describing why the command cannot be processed">Server internal error, check error message</response>
         [HttpGet]
         [Produces(MediaTypeNames.Text.Html)]
-        [ApiExplorerSettings(GroupName = "Alpaca")]
         [FeatureGate("HideAlpacaUI")]
         [Route("/setup/v1/telescope/{DeviceNumber}/setup")]
         public ActionResult<string> TelescopeSetup([Required][DefaultValue(0)][SwaggerSchema(Strings.DeviceIDDescription, Format = "uint32")][Range(0, 4294967295)] uint DeviceNumber)

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,6 +19,8 @@ COPY DomeSimulator/*.csproj ./DomeSimulator/
 COPY FilterWheelSimulator/*.csproj ./FilterWheelSimulator/
 COPY FocuserSimulator/*.csproj ./FocuserSimulator/
 COPY ObservingConditionsSimulator/*.csproj ./ObservingConditionsSimulator/
+COPY OmniSim.BaseDriver/*.csproj ./OmniSim.BaseDriver/
+COPY OmniSim.SettingsAPIGenerator/*.csproj ./OmniSim.SettingsAPIGenerator/
 COPY OmniSim.Tools/*.csproj ./OmniSim.Tools/
 COPY RotatorSimulator/*.csproj ./RotatorSimulator/
 COPY SafetyMonitorSimulator/*.csproj ./SafetyMonitorSimulator/

--- a/OmniSim.SettingsAPIGenerator/Program.cs
+++ b/OmniSim.SettingsAPIGenerator/Program.cs
@@ -41,9 +41,9 @@ namespace OmniSim.SettingsAPIGenerator
             builder.AppendLine("{");
 
             builder.AppendLine(ClassHeader);
-            builder.AppendLine($"public class {DeviceType}SettingsController : ProcessBaseController");
+            builder.AppendLine($"    public class {DeviceType}SettingsController : ProcessBaseController");
 
-            builder.AppendLine("{");
+            builder.AppendLine("    {");
 
             // Generate API for FilterWheel
             foreach (var prop in SettingsHelpers.GetSettingsProperties(DriverType))
@@ -135,7 +135,7 @@ using System.Net.Mime;
                 $"        /// <response code=\"500\" examples=\"Error message describing why the command cannot be processed\">Server internal error, check error message</response>\r\n" +
                 $"        [HttpGet]\r\n" +
                 $"        [Produces(MediaTypeNames.Application.Json)]\r\n" +
-                $"        [ApiExplorerSettings(GroupName = \"OmniSim\")]" +
+                $"        [ApiExplorerSettings(GroupName = \"OmniSim\")]\r\n" +
                 $"        [Route(\"{device.ToLower()}/{{DeviceNumber}}/{key.ToLower()}\")]\r\n" +
                 $"        public ActionResult<{responsetype}> {key}(\r\n" +
                 $"            [Required][DefaultValue(0)][SwaggerSchema(Strings.DeviceIDDescription, Format = \"uint32\")][Range(0, 4294967295)] uint DeviceNumber,\r\n" +
@@ -164,7 +164,7 @@ using System.Net.Mime;
                 $"        /// <response code=\"500\" examples=\"Error message describing why the command cannot be processed\">Server internal error, check error message</response>\r\n" +
                 $"        [HttpPut]\r\n" +
                 $"        [Produces(MediaTypeNames.Application.Json)]\r\n" +
-                $"        [ApiExplorerSettings(GroupName = \"OmniSim\")]" +
+                $"        [ApiExplorerSettings(GroupName = \"OmniSim\")]\r\n" +
                 $"        [Route(\"{device.ToLower()}/{{DeviceNumber}}/{key.ToLower()}\")]\r\n" +
                 $"        public ActionResult<Response> {key}(\r\n" +
                 $"            [Required][DefaultValue(0)][SwaggerSchema(Strings.DeviceIDDescription, Format = \"uint32\")][Range(0, 4294967295)] uint DeviceNumber,\r\n" +


### PR DESCRIPTION
Hi. 

I've recently pulled the latest changes of the repo, to run the latest version. I am on macOS and I prefer to run the simulators through Docker. I noticed they were missing `COPY` commands in the Dockerfile for the build to complete. Here is a small PR to add them.

Strangely enough, now the command `docker compose up --build` exit with code 0, but nothing is running? It's probably unrelated, and I should open an issue, isn't it? (I am not familiar at all on how the .NET world is working).